### PR TITLE
Step2 - GitHub(UI 레이어)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# 프로그래밍 요구 사항
+# Step 1 - GitHub(데이터 레이어)
+
+## 프로그래밍 요구 사항
 - NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
   - GET https://api.github.com/orgs/next-step/repos
   - full_name, description 필드만 가져온다.
@@ -6,8 +8,20 @@
 - 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
   - 실제로 서버 데이터가 잘 로드되는지 Log로 확인한다.
 
-# 기능 요구사항
+## 기능 요구사항
 -[O] 수동 DI를 구현한다.
 -[O] NEXTSTEP 조직의 저장소 목록을 가져오는 Client(Service)를 구현한다.
 -[O] 저장소 목록을 가져오는 기능은 data 패키지에 구현한다.
 -[O] Log를 통해 서버 데이터가 잘 로드되었는지 확인한다.
+
+# Step 2 - GitHub(UI 레이어)
+
+## 프로그래밍 요구 사항
+- Material3의 Theme을 활용하여 Typography와 Color를 부여한다.
+- 힌트 코드를 참고하여 ViewModel Factory를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
+- 저장소 목록을 노출하는 UI와 관련된 기능은 ui 패키지에 구현되어야 한다.
+  - UI 레이어는 데이터 레이어를 의존하지만, 데이터 레이어는 UI 레이어를 의존해선 안 된다.
+
+## 기능 요구사항
+- [] 저장소 목록을 노출하는 화면을 구현한다.
+- [] 저장소 목록을 가져오는 기능은 ViewModel에서 구현한다.

--- a/app/src/main/java/nextstep/github/GithubViewModel.kt
+++ b/app/src/main/java/nextstep/github/GithubViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import nextstep.github.core.data.GithubRepository
+import nextstep.github.core.network.ApiResult
 
 class GithubViewModel(
     private val githubRepository: GithubRepository
@@ -13,8 +14,19 @@ class GithubViewModel(
 
     fun getRepositories(organization: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            val result = githubRepository.getRepositories(organization)
-            Log.d("TAG", "getRepositories: $result")
+            try {
+                when (val result = githubRepository.getRepositories(organization)) {
+                    is ApiResult.Success -> {
+                        Log.d("GithubViewModel", "Success: ${result.value}")
+                    }
+
+                    is ApiResult.Error -> {
+                        Log.e("GithubViewModel", "Error1: ${result.code} ${result.exception}")
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("GithubViewModel", "Error2: ${e.message}")
+            }
         }
     }
 }

--- a/app/src/main/java/nextstep/github/GithubViewModel.kt
+++ b/app/src/main/java/nextstep/github/GithubViewModel.kt
@@ -2,21 +2,38 @@ package nextstep.github
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import nextstep.github.core.data.GithubRepository
+import nextstep.github.core.data.GithubRepositoryInfo
 import nextstep.github.core.network.ApiResult
 
 class GithubViewModel(
     private val githubRepository: GithubRepository
 ) : ViewModel() {
 
+    private val _githubRepositoryInfoList =
+        MutableStateFlow<List<GithubRepositoryInfo>>(emptyList())
+    val githubRepositoryInfoList: StateFlow<List<GithubRepositoryInfo>> = _githubRepositoryInfoList
+
     fun getRepositories(organization: String) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 when (val result = githubRepository.getRepositories(organization)) {
                     is ApiResult.Success -> {
+                        _githubRepositoryInfoList.value = result.value.map {
+                            GithubRepositoryInfo(
+                                fullName = it.fullName ?: "",
+                                description = it.description ?: ""
+                            )
+                        }
                         Log.d("GithubViewModel", "Success: ${result.value}")
                     }
 
@@ -26,6 +43,19 @@ class GithubViewModel(
                 }
             } catch (e: Exception) {
                 Log.e("GithubViewModel", "Error2: ${e.message}")
+            }
+        }
+    }
+
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val githubRepository = (this[APPLICATION_KEY] as MainApplication)
+                    .appContainer
+                    .githubRepository
+
+                GithubViewModel(githubRepository)
             }
         }
     }

--- a/app/src/main/java/nextstep/github/MainActivity.kt
+++ b/app/src/main/java/nextstep/github/MainActivity.kt
@@ -3,50 +3,36 @@ package nextstep.github
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import nextstep.github.ui.screen.github.MainScreen
 import nextstep.github.ui.theme.GithubTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val appContainer = (application as MainApplication).appContainer
-        val repository = appContainer.githubRepository
 
-        val viewModel = GithubViewModel(repository)
+        val viewModel: GithubViewModel by viewModels { GithubViewModel.Factory }
         viewModel.getRepositories("next-step")
 
         setContent {
             GithubTheme {
-                // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("Android")
+                    val repositoryInfoList by viewModel.githubRepositoryInfoList.collectAsStateWithLifecycle()
+
+                    MainScreen(
+                        githubRepositoryInfoList = repositoryInfoList
+                    )
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    GithubTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/nextstep/github/core/data/GithubRepository.kt
+++ b/app/src/main/java/nextstep/github/core/data/GithubRepository.kt
@@ -1,8 +1,9 @@
 package nextstep.github.core.data
 
 import nextstep.github.core.model.RepositoryEntity
+import nextstep.github.core.network.ApiResult
 
 
 interface GithubRepository {
-    suspend fun getRepositories(organization: String): List<RepositoryEntity>
+    suspend fun getRepositories(organization: String): ApiResult<List<RepositoryEntity>>
 }

--- a/app/src/main/java/nextstep/github/core/data/GithubRepositoryImpl.kt
+++ b/app/src/main/java/nextstep/github/core/data/GithubRepositoryImpl.kt
@@ -1,13 +1,20 @@
 package nextstep.github.core.data
 
 import nextstep.github.core.model.RepositoryEntity
+import nextstep.github.core.network.ApiResult
 import nextstep.github.core.network.GithubService
 
 class GithubRepositoryImpl(
     private val githubService: GithubService
 ) : GithubRepository {
 
-    override suspend fun getRepositories(organization: String): List<RepositoryEntity> {
-        return githubService.getRepositories(organization)
+    override suspend fun getRepositories(organization: String): ApiResult<List<RepositoryEntity>> {
+        val response = githubService.getRepositories(organization)
+
+        return if (response.isSuccessful && response.body() != null) {
+            ApiResult.Success(response.body()!!)
+        } else {
+            ApiResult.Error(response.code(), Throwable(response.message()))
+        }
     }
 }

--- a/app/src/main/java/nextstep/github/core/data/GithubRepositoryInfo.kt
+++ b/app/src/main/java/nextstep/github/core/data/GithubRepositoryInfo.kt
@@ -1,0 +1,6 @@
+package nextstep.github.core.data
+
+data class GithubRepositoryInfo(
+    val fullName: String,
+    val description: String,
+)

--- a/app/src/main/java/nextstep/github/core/di/AppContainer.kt
+++ b/app/src/main/java/nextstep/github/core/di/AppContainer.kt
@@ -7,14 +7,28 @@ import nextstep.github.core.data.GithubRepositoryImpl
 import nextstep.github.core.network.GithubService
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 
 class AppContainer {
 
     private val serialization = Json { ignoreUnknownKeys = true }
+    private val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
     private val retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
-        .client(OkHttpClient.Builder().build())
+        .client(
+            OkHttpClient
+                .Builder()
+                .addInterceptor(httpLoggingInterceptor)
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .build()
+        )
         .addConverterFactory(serialization.asConverterFactory(CONTENT_TYPE.toMediaType()))
         .build()
 

--- a/app/src/main/java/nextstep/github/core/model/RepositoryEntity.kt
+++ b/app/src/main/java/nextstep/github/core/model/RepositoryEntity.kt
@@ -2,9 +2,15 @@ package nextstep.github.core.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import nextstep.github.core.data.GithubRepositoryInfo
 
 @Serializable
 data class RepositoryEntity(
     @SerialName("full_name") val fullName: String?,
     @SerialName("description") val description: String?,
-)
+) {
+    fun RepositoryEntity.toRepositoryInfo() = GithubRepositoryInfo(
+        fullName = fullName ?: "",
+        description = description ?: ""
+    )
+}

--- a/app/src/main/java/nextstep/github/core/network/ApiResult.kt
+++ b/app/src/main/java/nextstep/github/core/network/ApiResult.kt
@@ -1,0 +1,6 @@
+package nextstep.github.core.network
+
+sealed class ApiResult<out T> {
+    data class Success<out T>(val value: T) : ApiResult<T>()
+    data class Error(val code: Int? = null, val exception: Throwable? = null) : ApiResult<Nothing>()
+}

--- a/app/src/main/java/nextstep/github/core/network/GithubService.kt
+++ b/app/src/main/java/nextstep/github/core/network/GithubService.kt
@@ -1,11 +1,12 @@
 package nextstep.github.core.network
 
 import nextstep.github.core.model.RepositoryEntity
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 
 interface GithubService {
     @GET("orgs/{organization}/repos")
-    suspend fun getRepositories(@Path("organization") organization: String): List<RepositoryEntity>
+    suspend fun getRepositories(@Path("organization") organization: String): Response<List<RepositoryEntity>>
 }

--- a/app/src/main/java/nextstep/github/ui/screen/github/MainScreen.kt
+++ b/app/src/main/java/nextstep/github/ui/screen/github/MainScreen.kt
@@ -1,33 +1,32 @@
-package nextstep.github.ui.screen.github.list
+package nextstep.github.ui.screen.github
 
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import nextstep.github.core.data.GithubRepositoryInfo
-import nextstep.github.ui.screen.github.list.component.RepositoryColumn
+import nextstep.github.ui.screen.github.component.MainTopBar
+import nextstep.github.ui.screen.github.list.GithubRepositoryList
 
 @Composable
-fun GithubRepositoryList(
-    githubRepositoryInfoList: List<GithubRepositoryInfo>,
-    modifier: Modifier = Modifier
+fun MainScreen(
+    githubRepositoryInfoList: List<GithubRepositoryInfo>
 ) {
-    LazyColumn(
-        modifier = modifier.fillMaxWidth()
-    ) {
-        items(githubRepositoryInfoList.size) {
-            RepositoryColumn(
-                repositoryInfo = githubRepositoryInfoList[it],
-                modifier = Modifier
-            )
-        }
+    Scaffold(
+        topBar = { MainTopBar() }
+    )
+    { paddingValues ->
+        GithubRepositoryList(
+            githubRepositoryInfoList = githubRepositoryInfoList,
+            modifier = Modifier.padding(paddingValues)
+        )
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
-private fun GithubRepositoryListPreview() {
+private fun MainScreenPreview() {
     val githubRepositoryList = listOf(
         GithubRepositoryInfo(
             fullName = "next-step/nextstep-study",
@@ -47,8 +46,7 @@ private fun GithubRepositoryListPreview() {
         )
     )
 
-    GithubRepositoryList(
-        githubRepositoryInfoList = githubRepositoryList,
-        modifier = Modifier
+    MainScreen(
+        githubRepositoryInfoList = githubRepositoryList
     )
 }

--- a/app/src/main/java/nextstep/github/ui/screen/github/component/MainTopBar.kt
+++ b/app/src/main/java/nextstep/github/ui/screen/github/component/MainTopBar.kt
@@ -1,0 +1,33 @@
+package nextstep.github.ui.screen.github.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import nextstep.github.R
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainTopBar(modifier: Modifier = Modifier) {
+    TopAppBar(
+        modifier = Modifier.fillMaxWidth(),
+        title = {
+            Text(
+                modifier = modifier.fillMaxWidth(),
+                text = stringResource(id = R.string.text_title),
+//                textAlign = TextAlign.Center,
+            )
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun MainTopBarPreview() {
+    MainTopBar()
+}

--- a/app/src/main/java/nextstep/github/ui/screen/github/list/GithubRepositoryList.kt
+++ b/app/src/main/java/nextstep/github/ui/screen/github/list/GithubRepositoryList.kt
@@ -1,0 +1,56 @@
+package nextstep.github.ui.screen.github.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import nextstep.github.core.data.GithubRepositoryInfo
+import nextstep.github.ui.screen.github.list.component.RepositoryColumn
+
+@Composable
+fun GithubRepositoryList(
+    githubRepositoryInfoList: List<GithubRepositoryInfo>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        items(githubRepositoryInfoList.size) {
+            RepositoryColumn(
+                repositoryInfo = githubRepositoryInfoList[it],
+                modifier = Modifier
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GithubRepositoryListPreview() {
+    val githubRepositoryList = listOf(
+        GithubRepositoryInfo(
+            fullName = "next-step/nextstep-study",
+            description = "코드숨과 함께하는 NextStep"
+        ),
+        GithubRepositoryInfo(
+            fullName = "next-step/nextstep-study",
+            description = "코드숨과 함께하는 NextStep"
+        ),
+        GithubRepositoryInfo(
+            fullName = "next-step/nextstep-study",
+            description = "코드숨과 함께하는 NextStep"
+        ),
+        GithubRepositoryInfo(
+            fullName = "next-step/nextstep-study",
+            description = "코드숨과 함께하는 NextStep"
+        )
+    )
+
+    GithubRepositoryList(
+        githubRepositoryInfoList = githubRepositoryList,
+        modifier = Modifier
+    )
+}

--- a/app/src/main/java/nextstep/github/ui/screen/github/list/component/RepositoryColumn.kt
+++ b/app/src/main/java/nextstep/github/ui/screen/github/list/component/RepositoryColumn.kt
@@ -1,0 +1,52 @@
+package nextstep.github.ui.screen.github.list.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import nextstep.github.core.data.GithubRepositoryInfo
+
+@Composable
+fun RepositoryColumn(repositoryInfo: GithubRepositoryInfo, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .padding(vertical = 16.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = repositoryInfo.fullName,
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxWidth()
+        )
+        Text(
+            text = repositoryInfo.description,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
+                .padding(horizontal = 16.dp,)
+                .background(MaterialTheme.colorScheme.surface)
+                .fillMaxWidth()
+        )
+    }
+    HorizontalDivider()
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RepositoryColumnPreview() {
+    RepositoryColumn(
+        repositoryInfo = GithubRepositoryInfo(
+            fullName = "next-step/nextstep-study",
+            description = "코드숨과 함께하는 NextStep"
+        )
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">GitHub</string>
+    <string name="text_title">NEXTSTEP Repositories</string>
 </resources>


### PR DESCRIPTION
안녕하세요 리뷰어님. 

UI레이어의 개념이 부족해 제대로 했는지 잘 모르겠네요...

몇가지 질문이 있습니다.

1. GithubRepositoryList은 통신 후 깃허브 저장소의 내용을 노출해주는 컴포넌트입니다.
 초기 GithubRepositoryList에 viewModel을 파라미터로 받는 컴포넌트와 응답 데이터를 파라미터로 받아 노출하는 컴포넌트로 오버로딩하여 구현하였습니다.
이후, 탑뷰 구현을 위해 MainScreen 컴포넌트를 구현하고 GithubRepositoryList 컴포넌트를 내부에 추가해주었습니다.
이떄 MainScreen의 프리뷰에서 GithubRepositoryList에 viewModel의 기능을 사용할 수 없어 프리뷰가 제대로 보여지지 상태가 되었습니다.
이를 해결하기 위해 MainActivity까지 ViewModel을 꺼내고 MainScreen와 GithubRepositoryList에는 응답받은 데이터를 파라미터로 전달해주었습니다.
이렇게 엑티비티까지 상태호이스팅을 진행하는 구조가 적절한지 알고싶습니다.

2. 현재 구현된 탑뷰의 padding에 특별한 설정을 하지 않은 거 같은데 padding(start = n.dp) 와 같이 왼쪽에서 조금 떨어저 있는 상태입니다.
어던 이유인지 알고싶습니다.
피그마에서는 가운데 타이틀이 노출되었지만 상태를 표시하기 위해 탑뷰 Text의 textAlign는 설정하지 않았습니다.

글 쓰는 재주가 부족합니다.
질문에 대해 이해가 안되신다면 DM부탁드리겠습니다.
감사합니다.