### PR TITLE
🚀 1단계 - GitHub(데이터 레이어)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # android-github-compose
+
+
+## **🚀 1단계 - GitHub(데이터 레이어)**
+
+---
+
+### 구현 기능 목록
+
+- NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
+    - **`GET`** https://api.github.com/orgs/next-step/repos
+    - **`full_name`**, **`description`** 필드만 가져온다.
+- 네트워크 요청으로 저장소 목록을 가져오는 기능은 **`data`** 패키지에 구현되어야 한다.
+- 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
+    - 실제로 서버 데이터가 잘 로드되는지 **`Log`**로 확인한다.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 android {
@@ -66,4 +67,9 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation(libs.retrofit2)
+    implementation(libs.okhttp)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.retrofit2.kotlinx.serialization.converter)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".GithubApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/nextstep/github/GithubApplication.kt
+++ b/app/src/main/java/nextstep/github/GithubApplication.kt
@@ -1,0 +1,8 @@
+package nextstep.github
+
+import android.app.Application
+import nextstep.github.di.AppContainer
+
+class GithubApplication : Application() {
+    val appContainer = AppContainer()
+}

--- a/app/src/main/java/nextstep/github/MainActivity.kt
+++ b/app/src/main/java/nextstep/github/MainActivity.kt
@@ -1,6 +1,7 @@
 package nextstep.github
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import nextstep.github.ui.theme.GithubTheme
@@ -15,9 +17,16 @@ import nextstep.github.ui.theme.GithubTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val appContainer = (application as GithubApplication).appContainer
+        val githubRepository = appContainer.githubRepository
+
         setContent {
             GithubTheme {
                 // A surface container using the 'background' color from the theme
+                LaunchedEffect(Unit) {
+                    Log.d("결과",githubRepository.getRepositories("next-step").toString())
+                }
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/nextstep/github/data/GithubRepository.kt
+++ b/app/src/main/java/nextstep/github/data/GithubRepository.kt
@@ -1,0 +1,8 @@
+package nextstep.github.data
+
+import nextstep.github.network.RepositoryEntity
+
+interface GithubRepository {
+
+    suspend fun getRepositories(organization: String): List<RepositoryEntity>
+}

--- a/app/src/main/java/nextstep/github/data/GithubRepositoryImpl.kt
+++ b/app/src/main/java/nextstep/github/data/GithubRepositoryImpl.kt
@@ -1,0 +1,9 @@
+package nextstep.github.data
+
+import nextstep.github.network.GithubService
+import nextstep.github.network.RepositoryEntity
+
+class GithubRepositoryImpl(private val githubService: GithubService) : GithubRepository {
+    override suspend fun getRepositories(organization: String): List<RepositoryEntity> =
+        githubService.getRepositories(organization = organization)
+}

--- a/app/src/main/java/nextstep/github/di/AppContainer.kt
+++ b/app/src/main/java/nextstep/github/di/AppContainer.kt
@@ -1,0 +1,30 @@
+package nextstep.github.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import nextstep.github.data.GithubRepository
+import nextstep.github.data.GithubRepositoryImpl
+import nextstep.github.network.GithubService
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+class AppContainer {
+    private val serialization = Json { ignoreUnknownKeys = true }
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(OkHttpClient.Builder().build())
+        .addConverterFactory(serialization.asConverterFactory(CONTENT_TYPE.toMediaType()))
+        .build()
+
+    private val githubService = retrofit
+        .create(GithubService::class.java)
+
+    val githubRepository: GithubRepository = GithubRepositoryImpl(githubService)
+
+    companion object {
+        private const val CONTENT_TYPE = "application/json"
+        private const val BASE_URL = "https://api.github.com"
+    }
+}

--- a/app/src/main/java/nextstep/github/network/GithubService.kt
+++ b/app/src/main/java/nextstep/github/network/GithubService.kt
@@ -1,0 +1,11 @@
+package nextstep.github.network
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface GithubService {
+
+    @GET("orgs/{organization}/repos")
+    suspend fun getRepositories(@Path("organization") organization: String): List<RepositoryEntity>
+
+}

--- a/app/src/main/java/nextstep/github/network/RepositoryEntity.kt
+++ b/app/src/main/java/nextstep/github/network/RepositoryEntity.kt
@@ -1,0 +1,10 @@
+package nextstep.github.network
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RepositoryEntity(
+    @SerialName("full_name") val fullName: String?,
+    @SerialName("description") val description: String?
+)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.kotlinSerialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,11 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 
+kotlinxSerializationJson = "1.6.3"
+retrofit2KotlinxSerializationConverter = "1.0.0"
+okhttp = "4.12.0"
+retrofit2 = "2.11.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -27,7 +32,14 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
+
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+retrofit2 = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
### 구현 기능 목록

- [x]  NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
    - **`GET`** https://api.github.com/orgs/next-step/repos
    - **`full_name`**, **`description`** 필드만 가져온다.
- [x]  네트워크 요청으로 저장소 목록을 가져오는 기능은 **`data`** 패키지에 구현되어야 한다.
- [x]  힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
    - [x]  실제로 서버 데이터가 잘 로드되는지 **`Log`**로 확인한다.