### PR TITLE
🚀 1단계 - GitHub(데이터 레이어)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # android-github-compose
+
+## 1단계 - GitHub(데이터 레이어) 요구사항
+- [x] NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
+- [x] full_name, description 필드만 가져온다.
+- [x] 네트워크 요청으로 저장소 목록을 가져오는 기능은 data 패키지에 구현되어야 한다.
+- [x] 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
+- [x] 실제로 서버 데이터가 잘 로드되는지 Log로 확인한다.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.retrofit2.kotlinx.serialization.converter)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.okhttp)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 android {
@@ -59,6 +60,9 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.retrofit2.kotlinx.serialization.converter)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".GithubApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/nextstep/github/GithubApplication.kt
+++ b/app/src/main/java/nextstep/github/GithubApplication.kt
@@ -1,0 +1,9 @@
+package nextstep.github
+
+import android.app.Application
+import nextstep.github.data.AppContainer
+
+class GithubApplication: Application() {
+
+    val appContainer = AppContainer()
+}

--- a/app/src/main/java/nextstep/github/MainActivity.kt
+++ b/app/src/main/java/nextstep/github/MainActivity.kt
@@ -1,6 +1,7 @@
 package nextstep.github
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,11 +11,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import nextstep.github.ui.theme.GithubTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val appContainer = (application as GithubApplication).appContainer
+        val githubRepository = appContainer.githubRepository
+
+        lifecycleScope.launch {
+            val repositories = githubRepository.getRepositories(NEXT_STEP_ORGANIZATION)
+            Log.d("bandal", "repositories: $repositories")
+        }
+
         setContent {
             GithubTheme {
                 // A surface container using the 'background' color from the theme
@@ -26,6 +38,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    companion object {
+        private const val NEXT_STEP_ORGANIZATION = "next-step"
     }
 }
 

--- a/app/src/main/java/nextstep/github/data/AppContainer.kt
+++ b/app/src/main/java/nextstep/github/data/AppContainer.kt
@@ -1,26 +1,46 @@
 package nextstep.github.data
 
+import android.util.Log
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.serialization.json.Json
 import nextstep.github.data.repositories.impls.RemoteGithubRepository
 import nextstep.github.data.services.GithubService
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
 
 class AppContainer {
     private val serialization = Json { ignoreUnknownKeys = true }
+
+    private val httpLoggingInterceptor = HttpLoggingInterceptor { message ->
+        Log.d(TAG_HTTP_LOG, message)
+    }.apply { setLevel(HttpLoggingInterceptor.Level.BODY) }
+
+    private val okHttpClient = OkHttpClient
+        .Builder()
+        .addInterceptor(httpLoggingInterceptor)
+        .connectTimeout(CONNECT_TIMEOUT, TimeUnit.SECONDS)
+        .writeTimeout(WRITE_TIMEOUT, TimeUnit.SECONDS)
+        .readTimeout(READ_TIMEOUT, TimeUnit.SECONDS)
+        .build()
+
     private val retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
-        .client(OkHttpClient.Builder().build())
+        .client(okHttpClient)
         .addConverterFactory(serialization.asConverterFactory(CONTENT_TYPE.toMediaType()))
         .build()
-    private val githubService = retrofit
-        .create(GithubService::class.java)
+
+    private val githubService = retrofit.create(GithubService::class.java)
 
     val githubRepository = RemoteGithubRepository(githubService)
 
-        companion object {
+    companion object {
+        private const val TAG_HTTP_LOG = "Http_Log"
+        private const val CONNECT_TIMEOUT = 20L
+        private const val WRITE_TIMEOUT = 20L
+        private const val READ_TIMEOUT = 20L
         private const val CONTENT_TYPE = "application/json"
         private const val BASE_URL = "https://api.github.com"
     }

--- a/app/src/main/java/nextstep/github/data/AppContainer.kt
+++ b/app/src/main/java/nextstep/github/data/AppContainer.kt
@@ -1,0 +1,27 @@
+package nextstep.github.data
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import nextstep.github.data.repositories.impls.RemoteGithubRepository
+import nextstep.github.data.services.GithubService
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+class AppContainer {
+    private val serialization = Json { ignoreUnknownKeys = true }
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(OkHttpClient.Builder().build())
+        .addConverterFactory(serialization.asConverterFactory(CONTENT_TYPE.toMediaType()))
+        .build()
+    private val githubService = retrofit
+        .create(GithubService::class.java)
+
+    val githubRepository = RemoteGithubRepository(githubService)
+
+        companion object {
+        private const val CONTENT_TYPE = "application/json"
+        private const val BASE_URL = "https://api.github.com"
+    }
+}

--- a/app/src/main/java/nextstep/github/data/entities/RepositoryEntity.kt
+++ b/app/src/main/java/nextstep/github/data/entities/RepositoryEntity.kt
@@ -5,6 +5,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class RepositoryEntity(
-    @SerialName("full_name") val fullName: String?,
-    @SerialName("description") val description: String?,
+
+    @SerialName("full_name")
+    val fullName: String?,
+
+    @SerialName("description")
+    val description: String?,
 )

--- a/app/src/main/java/nextstep/github/data/entities/RepositoryEntity.kt
+++ b/app/src/main/java/nextstep/github/data/entities/RepositoryEntity.kt
@@ -1,0 +1,10 @@
+package nextstep.github.data.entities
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RepositoryEntity(
+    @SerialName("full_name") val fullName: String?,
+    @SerialName("description") val description: String?,
+)

--- a/app/src/main/java/nextstep/github/data/repositories/GithubRepository.kt
+++ b/app/src/main/java/nextstep/github/data/repositories/GithubRepository.kt
@@ -1,0 +1,8 @@
+package nextstep.github.data.repositories
+
+import nextstep.github.data.entities.RepositoryEntity
+
+interface GithubRepository {
+
+    suspend fun getRepositories(organization: String): List<RepositoryEntity>
+}

--- a/app/src/main/java/nextstep/github/data/repositories/impls/RemoteGithubRepository.kt
+++ b/app/src/main/java/nextstep/github/data/repositories/impls/RemoteGithubRepository.kt
@@ -1,0 +1,13 @@
+package nextstep.github.data.repositories.impls
+
+import nextstep.github.data.entities.RepositoryEntity
+import nextstep.github.data.repositories.GithubRepository
+import nextstep.github.data.services.GithubService
+
+class RemoteGithubRepository(
+    private val githubService: GithubService,
+) : GithubRepository {
+    override suspend fun getRepositories(organization: String): List<RepositoryEntity> {
+        return githubService.getRepositories(organization = organization)
+    }
+}

--- a/app/src/main/java/nextstep/github/data/services/GithubService.kt
+++ b/app/src/main/java/nextstep/github/data/services/GithubService.kt
@@ -1,0 +1,10 @@
+package nextstep.github.data.services
+
+import nextstep.github.data.entities.RepositoryEntity
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface GithubService {
+    @GET("orgs/{organization}/repos")
+    suspend fun getRepositories(@Path("organization") organization: String): List<RepositoryEntity>
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 kotlinxSerializationJson = "1.6.3"
 retrofit2KotlinxSerializationConverter = "1.0.0"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,6 +31,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
+kotlinxSerializationJson = "1.6.3"
+retrofit2KotlinxSerializationConverter = "1.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,8 +28,11 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## 1단계 - GitHub(데이터 레이어) 요구사항
- [x] NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
- [x] full_name, description 필드만 가져온다.
- [x] 네트워크 요청으로 저장소 목록을 가져오는 기능은 data 패키지에 구현되어야 한다.
- [x] 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
- [x] 실제로 서버 데이터가 잘 로드되는지 Log로 확인한다.

---

안녕하세요! 
우테코 5기때 제 첫 리뷰어셨는데, 이번엔 제 넥스트 스텝 미션의 마지막 리뷰어시군요!
잘부탁드립니다!