### PR TITLE
🚀 1단계 - GitHub(데이터 레이어)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # android-github-compose
+
+## 🚀 1단계 - GitHub(데이터 레이어)
+
+- NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
+  - GET https://api.github.com/orgs/next-step/repos
+  - full_name, description 필드만 가져온다.
+- 네트워크 요청으로 저장소 목록을 가져오는 기능은 data 패키지에 구현되어야 한다.
+- 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
+  - 실제로 서버 데이터가 잘 로드되는지 Log로 확인한다.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 android {
@@ -59,6 +60,13 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+
+    implementation(libs.retrofit2)
+    implementation(libs.okhttp3.logging.interceptor)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.retrofit2.kotlinx.serialization.converter)
+
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:name=".GitHubApplication"
         android:theme="@style/Theme.Github"
         tools:targetApi="31">
         <activity

--- a/app/src/main/java/nextstep/github/GitHubApplication.kt
+++ b/app/src/main/java/nextstep/github/GitHubApplication.kt
@@ -1,0 +1,8 @@
+package nextstep.github
+
+import android.app.Application
+import nextstep.github.di.AppContainer
+
+class GitHubApplication : Application() {
+    val appContainer = AppContainer()
+}

--- a/app/src/main/java/nextstep/github/MainActivity.kt
+++ b/app/src/main/java/nextstep/github/MainActivity.kt
@@ -1,6 +1,7 @@
 package nextstep.github
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,11 +11,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
 import nextstep.github.ui.theme.GithubTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            val appContainer = (application as GitHubApplication).appContainer
+            val repository = appContainer.githubRepository
+            repository.getRepositories().let {
+                Log.e("DEV_LOG", "data: $it")
+            }
+        }
+
         setContent {
             GithubTheme {
                 // A surface container using the 'background' color from the theme

--- a/app/src/main/java/nextstep/github/data/api/GitHubApiService.kt
+++ b/app/src/main/java/nextstep/github/data/api/GitHubApiService.kt
@@ -1,0 +1,10 @@
+package nextstep.github.data.api
+
+import nextstep.github.data.model.dto.RepositoryResponse
+import retrofit2.http.GET
+
+interface GitHubApiService {
+
+    @GET("orgs/next-step/repos")
+    suspend fun getRepositories(): List<RepositoryResponse>
+}

--- a/app/src/main/java/nextstep/github/data/datasource/GitHubRemoteDataSource.kt
+++ b/app/src/main/java/nextstep/github/data/datasource/GitHubRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package nextstep.github.data.datasource
+
+import nextstep.github.data.model.dto.RepositoryResponse
+
+interface GitHubRemoteDataSource {
+    suspend fun getRepositories(): List<RepositoryResponse>
+}

--- a/app/src/main/java/nextstep/github/data/datasource/GithubRemoteDataSourceImpl.kt
+++ b/app/src/main/java/nextstep/github/data/datasource/GithubRemoteDataSourceImpl.kt
@@ -1,0 +1,12 @@
+package nextstep.github.data.datasource
+
+import nextstep.github.data.api.GitHubApiService
+import nextstep.github.data.model.dto.RepositoryResponse
+
+class GithubRemoteDataSourceImpl(
+    private val _service: GitHubApiService,
+) : GitHubRemoteDataSource {
+    override suspend fun getRepositories(): List<RepositoryResponse> {
+        return _service.getRepositories()
+    }
+}

--- a/app/src/main/java/nextstep/github/data/model/dto/RepositoryResponse.kt
+++ b/app/src/main/java/nextstep/github/data/model/dto/RepositoryResponse.kt
@@ -1,0 +1,10 @@
+package nextstep.github.data.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RepositoryResponse(
+    @SerialName("full_name") val fullName: String?,
+    @SerialName("description") val description: String?,
+)

--- a/app/src/main/java/nextstep/github/data/repository/GitHubRepository.kt
+++ b/app/src/main/java/nextstep/github/data/repository/GitHubRepository.kt
@@ -1,0 +1,7 @@
+package nextstep.github.data.repository
+
+import nextstep.github.data.model.dto.RepositoryResponse
+
+interface GitHubRepository {
+    suspend fun getRepositories(): List<RepositoryResponse>
+}

--- a/app/src/main/java/nextstep/github/data/repository/GitHubRepositoryImpl.kt
+++ b/app/src/main/java/nextstep/github/data/repository/GitHubRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package nextstep.github.data.repository
+
+import nextstep.github.data.datasource.GitHubRemoteDataSource
+import nextstep.github.data.model.dto.RepositoryResponse
+
+class GitHubRepositoryImpl(
+    private val _remoteDataSource: GitHubRemoteDataSource
+) : GitHubRepository {
+    override suspend fun getRepositories(): List<RepositoryResponse> {
+        return _remoteDataSource.getRepositories()
+    }
+}

--- a/app/src/main/java/nextstep/github/di/AppContainer.kt
+++ b/app/src/main/java/nextstep/github/di/AppContainer.kt
@@ -1,0 +1,41 @@
+package nextstep.github.di
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import nextstep.github.data.api.GitHubApiService
+import nextstep.github.data.datasource.GitHubRemoteDataSource
+import nextstep.github.data.datasource.GithubRemoteDataSourceImpl
+import nextstep.github.data.repository.GitHubRepository
+import nextstep.github.data.repository.GitHubRepositoryImpl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.create
+
+class AppContainer {
+
+    private val serialization: Json = Json { ignoreUnknownKeys = true }
+
+    private val client: OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .build()
+
+    private val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(serialization.asConverterFactory(CONTENT_TYPE.toMediaType()))
+        .build()
+
+    private val githubService: GitHubApiService = retrofit.create<GitHubApiService>()
+    private val githubRemoteSource: GitHubRemoteDataSource = GithubRemoteDataSourceImpl(githubService)
+    val githubRepository: GitHubRepository = GitHubRepositoryImpl(githubRemoteSource)
+
+    companion object {
+        private const val CONTENT_TYPE = "application/json"
+        private const val BASE_URL = "https://api.github.com/"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,11 @@ lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 
+kotlinxSerializationJson = "1.6.3"
+retrofit2 = "2.11.0"
+retrofit2KotlinxSerializationConverter = "1.0.0"
+okhttp3LoggingInterceptor = "4.12.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -26,8 +31,13 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+retrofit2 = {module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit2"}
+retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2KotlinxSerializationConverter" }
+okhttp3-logging-interceptor = {module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp3LoggingInterceptor"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION

- NEXTSTEP 조직의 저장소 목록을 가져오는 Client를 구현한다.
  - GET https://api.github.com/orgs/next-step/repos
  - full_name, description 필드만 가져온다.
- 네트워크 요청으로 저장소 목록을 가져오는 기능은 data 패키지에 구현되어야 한다.
- 힌트 코드를 참고하여 수동 DI를 구현한다. (Hilt와 같은 별도의 DI 라이브러리를 활용하지 않는다)
  - 실제로 서버 데이터가 잘 로드되는지 Log로 확인한다.
